### PR TITLE
better stilr usage

### DIFF
--- a/stilr/button.js
+++ b/stilr/button.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import StyleSheet from 'stilr';
 
+const breakpoint = '@media (max-width: 480px)';
 let styles = StyleSheet.create({
   container: {
     textAlign: 'center'
@@ -19,7 +20,7 @@ let styles = StyleSheet.create({
       position: 'relative',
       top: '2px'
     },
-    ['@media (max-width: 480px)']: {
+    [breakpoint]: {
       width: '160px !important'
     }
   }
@@ -36,5 +37,13 @@ let Button = React.createClass({
 });
 
 if (typeof window !== 'undefined') {
+
+  // If running in production and a seperate stylesheet is required,
+  // extract the stylesheet by running `make extract-styles`
+
+  let stylesheet = document.createElement('style');
+  stylesheet.textContent = StyleSheet.render();
+  document.head.appendChild(stylesheet);
+
   React.render(<Button />, document.getElementById('content'));
 }

--- a/stilr/index.html
+++ b/stilr/index.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <title>stilr - CSS in JS</title>
-    <link rel="stylesheet" href="bundle.css">
   </head>
   <body>
     <div id="content"></div>


### PR DESCRIPTION
I took the liberty to change the way Stilr should be used in development.
`npm build` stil extracts the bundled css but the bundled js inserts the CSS dynamically but with an explanation on how to extract it if running in production.

If css-in-js should be a reflection on how to use the different techniques in production, then feel free to scrap this PR :)