### PR TITLE
Add babel-plugin-css-in-js

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ For example, if a package supports the css file extraction you can run the autop
 
 | Package | Version | Autoprefixer Included | Pseudo Classes | Media Queries | Styles As Object Literals | Extract CSS File |
 |---------|:-------:|:---------------------:|:--------------:|:-------------:|:-------------------------:|:----------------:|
+| [babel-plugin-css-in-js](https://github.com/martinandert/babel-plugin-css-in-js) | 0.1.0 | x | x | x | x | x |
 | [bloody-react-styled](https://github.com/bloodyowl/react-styled) | 3.0.0 | | x | x | | |
 | [classy](https://github.com/inturn/classy) | 0.3.0 | | x | x | x | |
 | [css-loader](https://github.com/webpack/css-loader) | 0.15.6 | | x | x | | x |

--- a/babel-plugin-css-in-js/.babelrc
+++ b/babel-plugin-css-in-js/.babelrc
@@ -1,0 +1,9 @@
+{
+  "presets": [
+    "es2015",
+    "react"
+  ],
+  "plugins": [
+    "css-in-js"
+  ]
+}

--- a/babel-plugin-css-in-js/button.js
+++ b/babel-plugin-css-in-js/button.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render } from 'react-dom';
+
+const styles = cssInJS({
+  container: {
+    textAlign: 'center'
+  },
+  button: {
+    backgroundColor: '#ff0000',
+    width: 320,
+    padding: 20,
+    borderRadius: 5,
+    border: 'none',
+    outline: 'none',
+    ':hover': {
+      color: '#fff'
+    },
+    ':active': {
+      position: 'relative',
+      top: 2
+    },
+    '@media (max-width: 480px)': {
+      width: 160
+    }
+  }
+});
+
+class Button extends React.Component {
+  render() {
+    return (
+      <div className={styles.container}>
+        <button className={styles.button}>Click me!</button>
+      </div>
+    );
+  }
+}
+
+render(<Button />, document.getElementById('content'));

--- a/babel-plugin-css-in-js/index.html
+++ b/babel-plugin-css-in-js/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>babel-plugin-css-in-js - CSS in JS</title>
+    <link rel="stylesheet" href="bundle.css">
+  </head>
+  <body>
+    <div id="content"></div>
+    <script src="bundle.js"></script>
+  </body>
+</html>

--- a/babel-plugin-css-in-js/package.json
+++ b/babel-plugin-css-in-js/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "babel-plugin-css-in-js",
+  "version": "1.0.0",
+  "description": "babel-plugin-css-in-js - CSS in JS",
+  "scripts": {
+    "build": "webpack ./button.js bundle.js"
+  },
+  "author": "Martin Andert",
+  "license": "MIT",
+  "dependencies": {
+    "react": "^0.14.2",
+    "react-dom": "^0.14.2"
+  },
+  "devDependencies": {
+    "babel-core": "^6.1.21",
+    "babel-loader": "^6.1.0",
+    "babel-plugin-css-in-js": "^0.1.0",
+    "babel-preset-es2015": "^6.1.18",
+    "babel-preset-react": "^6.1.18",
+    "webpack": "^1.12.6"
+  }
+}

--- a/babel-plugin-css-in-js/webpack.config.js
+++ b/babel-plugin-css-in-js/webpack.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  module: {
+    loaders: [{
+      test: /\.js$/,
+      exclude: /node_modules/,
+      loader: 'babel'
+    }]
+  }
+}


### PR DESCRIPTION
This is basically react-inline as a babel plugin. Now that v6 of babel supports plugin options, this can be directly integrated into babel's transformation pipeline.