### PR TITLE
Update j2c info

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For example, if a package supports the css file extraction you can run the autop
 | [bloody-react-styled](https://github.com/bloodyowl/react-styled) | 3.0.0 | | x | x | | |
 | [classy](https://github.com/inturn/classy) | 0.3.0 | | x | x | x | |
 | [css-loader](https://github.com/webpack/css-loader) | 0.15.6 | | x | x | | x |
-| [j2c](https://github.com/pygy/j2c) | 0.7.3 | x | x | x | x | |
+| [j2c](https://github.com/pygy/j2c) | 0.10.0 | | x | x | x | x |
 | [jsxstyle](https://github.com/petehunt/jsxstyle) | 0.0.14 | x | | | x | |
 | [radium](https://github.com/FormidableLabs/radium) | 0.13.5 | x | x | x | x | |
 | [react-css-builder](https://github.com/jhudson8/react-css-builder) | 0.2.0 | | | | x | |

--- a/j2c/button.js
+++ b/j2c/button.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import j2c from 'j2c';
 
-const styles = j2c.scoped({
-  container: {
+const styles = j2c.sheet({
+  '.container': {
     'text-align': 'center'
   },
-  button: {
+  '.button': {
     'background-color': '#ff0000',
     width: '320px',
     padding: '20px',

--- a/j2c/package.json
+++ b/j2c/package.json
@@ -8,7 +8,7 @@
   "author": "Michele Bertoli",
   "license": "MIT",
   "dependencies": {
-    "j2c": "^0.7.3",
+    "j2c": "^0.10.0",
     "react": "^0.13.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Hello Michele,

here's an update to the `j2c` information and example. `j2c` doesn't support `autoprefixer` at the moment, even though a plugin is in the works.

Thanks again for making this list.