### PR TITLE
Added hyperstyles

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ For example, if a package supports the css file extraction you can run the autop
 | [classy](https://github.com/inturn/classy) | 0.3.0 | | x | x | x | |
 | [csjs](https://github.com/rtsao/csjs) | 1.0.0 | | x | x | | |
 | [css-loader](https://github.com/webpack/css-loader) | 0.15.6 | | x | x | | x |
+| [hyperstyles](https://github.com/colingourlay/hyperstyles) | 3.3.0 | | x | x | | x |
 | [j2c](https://github.com/j2css/j2c) | 0.10.0 | | x | x | x | x |
 | [jsxstyle](https://github.com/petehunt/jsxstyle) | 0.0.14 | x | | | x | |
 | [radium](https://github.com/FormidableLabs/radium) | 0.13.5 | x | x | x | x | |

--- a/hyperstyles/button.css
+++ b/hyperstyles/button.css
@@ -1,0 +1,28 @@
+.container {
+  text-align: center;
+}
+
+.button {
+  background-color: #ff0000;
+  width: 320px;
+  padding: 20px;
+  border-radius: 5px;
+  border: none;
+  outline: none;
+}
+
+.button:hover {
+  color: #fff;
+}
+
+.button:active {
+  position: relative;
+  top: 2px;
+}
+
+@media (max-width: 480px) {
+  .button {
+    width: 160px
+  }
+}
+

--- a/hyperstyles/button.js
+++ b/hyperstyles/button.js
@@ -1,0 +1,20 @@
+/** @jsx h */
+
+import React, {Component} from 'react';
+import hyperstyles from 'hyperstyles';
+
+import styles from './button.css';
+
+const h = hyperstyles(React.createElement, styles);
+
+class Button extends Component {
+  render() {
+    return (
+      <div styleName="container">
+        <button styleName="button">Click me!</button>
+      </div>
+    );
+  }
+};
+
+React.render(<Button />, document.getElementById('content'));

--- a/hyperstyles/index.html
+++ b/hyperstyles/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>hyperstyles - CSS in JS</title>
+    <link rel="stylesheet" href="bundle.css">
+  </head>
+  <body>
+    <div id="content"></div>
+    <script src="bundle.js"></script>
+  </body>
+</html>

--- a/hyperstyles/package.json
+++ b/hyperstyles/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "hyperstyles-css-in-js",
+  "version": "1.0.0",
+  "description": "hyperstyles - CSS in JS",
+  "scripts": {
+    "build": "webpack ./button.js bundle.js"
+  },
+  "author": "Colin Gourlay",
+  "license": "MIT",
+  "dependencies": {
+    "react": "^0.13.3",
+    "hyperstyles": "^3.3.0"
+  },
+  "devDependencies": {
+    "babel-loader": "^5.1.3",
+    "css-loader": "^0.15.6",
+    "extract-text-webpack-plugin": "^0.8.0",
+    "style-loader": "^0.12.3",
+    "webpack": "^1.9.9"
+  }
+}

--- a/hyperstyles/webpack.config.js
+++ b/hyperstyles/webpack.config.js
@@ -1,0 +1,17 @@
+var ExtractTextPlugin = require('extract-text-webpack-plugin');
+
+module.exports = {
+  module: {
+    loaders: [{
+      test: /\.jsx?$/,
+      exclude: /(node_modules|bower_components)/,
+      loader: 'babel?stage=0'
+    }, {
+      test: /\.css$/,
+      loader: ExtractTextPlugin.extract('style', 'css?modules')
+    }]
+  },
+  plugins: [
+    new ExtractTextPlugin('bundle.css')
+  ]
+}


### PR DESCRIPTION
I originally pitched [hyperstyles](https://github.com/colingourlay/hyperstyles) towards the end of last year, but at the time it was a transparent transform for `virtual-hyperscript`, and rejected for the fair reason that this is an exclusive collection of React examples.

Since then, hyperstyles has been rewritten to be a transform for _any_ DOM creation utility that has a hyperscript-like signature, including `React.createElement`.

I've added an example in the `hyperstyles` directory which shows how it would work with React+JSX.