### PR TITLE
:memo: react-free-style can extract the CSS file

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ For example, if a package supports the css file extraction you can run the autop
 | [radium](https://github.com/FormidableLabs/radium) | 0.13.5 | x | x | x | x | |
 | [react-css-builder](https://github.com/jhudson8/react-css-builder) | 0.2.0 | | | | x | |
 | [react-css-modules](https://github.com/gajus/react-css-modules) | 3.0.2 | | x | x | | x |
-| [react-free-style](https://github.com/blakeembrey/react-free-style) | 0.6.0 | | x | x | x | |
+| [react-free-style](https://github.com/blakeembrey/react-free-style) | 0.6.0 | | x | x | x | x |
 | [react-inline-css](https://github.com/RickWong/react-inline-css) | 1.2.0 | | x | x | | |
 | [react-inline](https://github.com/martinandert/react-inline) | 0.6.3 | x | x | x | x | x |
 | [react-inline-style](https://github.com/dowjones/react-inline-style) | 0.1.0 | x | x | x | x | |


### PR DESCRIPTION
Just call `Style.getStyles()` : https://github.com/blakeembrey/free-style#css-string 

Note that `ReactFreeStyle` is just an extension of the `FreeStyle` class [src](https://github.com/blakeembrey/react-free-style/blob/4d71b84ab806369d17f40f3c89b2cc8031c192ef/src/react-free-style.ts#L8) :rose: 