### PR TITLE
Add missing peerDependency "babel-core"

### DIFF
--- a/glamor/package.json
+++ b/glamor/package.json
@@ -13,6 +13,7 @@
     "react-dom": "^15.2.1"
   },
   "devDependencies": {
+    "babel-core": "^6.18.2",
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.11.1",


### PR DESCRIPTION
```sh
$ npm ls --depth=0
glamor-css-css-in-js@1.0.0 /**/css-in-js/glamor
├── UNMET PEER DEPENDENCY babel-core@^6.0.0
├── babel-loader@6.2.8
├── babel-preset-es2015@6.18.0
├── babel-preset-react@6.16.0
├── glamor@2.20.3
├── react@15.4.1
├── react-dom@15.4.1
└── webpack@1.13.3

npm ERR! peer dep missing: babel-core@^6.0.0, required by babel-loader@6.2.8
```